### PR TITLE
count(): simply return total number of items if no function supplied.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -195,7 +195,8 @@ users
 
 ## .count(fn:Function)
 
-  Count the number of times `fn(val, i)` returns true.
+  Count the number of times `fn(val, i)` returns true
+  or, if no function supplied, return total number of values.
 
 ```js
  var n = pets.count(function(pet){

--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ users
   - [.none()](#nonefnfunctionstring)
   - [.any()](#anyfnfunction)
   - [.count()](#countfnfunction)
+  - [.length()](#length)
   - [.indexOf()](#indexofobjmixed)
   - [.has()](#hasobjmixed)
   - [.reduce()](#reducefnfunctionvalmixed)
@@ -203,6 +204,10 @@ users
    return pet.species == 'ferret'
  })
 ```
+
+## .length()
+
+  Return total number of values.
 
 ## .indexOf(obj:Mixed)
 

--- a/index.js
+++ b/index.js
@@ -405,6 +405,18 @@ proto.count = function(fn){
 };
 
 /**
+ * Return total number of values.
+ *
+ * @return {Number}
+ * @api public
+ */
+
+proto.length = function() {
+  var vals = this.__iterate__();
+  return vals.length();
+};
+
+/**
  * Determine the indexof `obj` or return `-1`.
  *
  * @param {Mixed} obj

--- a/index.js
+++ b/index.js
@@ -379,7 +379,8 @@ proto.any = function(fn){
 };
 
 /**
- * Count the number of times `fn(val, i)` returns true.
+ * Count the number of times `fn(val, i)` returns true
+ * or, if no function supplied, return total number of values.
  *
  *    var n = pets.count(function(pet){
  *      return pet.species == 'ferret'
@@ -394,6 +395,7 @@ proto.count = function(fn){
   var val;
   var vals = this.__iterate__();
   var len = vals.length();
+  if (!fn) return len;
   var n = 0;
   for (var i = 0; i < len; ++i) {
     val = vals.get(i);

--- a/test/index.js
+++ b/test/index.js
@@ -336,9 +336,16 @@ describe('.count(fn)', function(){
     var arr = Enumerable([1,2,3,4,5]);
     arr.count(function(n){ return n > 3 }).should.equal(2);
   })
-  it('should return total items if no function given', function(){
+  it('should return total number of items if no function given', function(){
     var arr = Enumerable([1,2,3,4,5]);
     arr.count().should.equal(5);
+  })
+})
+
+describe('.length()', function() {
+  it('should return total number of items', function(){
+    var arr = Enumerable([1,2,3,4,5]);
+    arr.length().should.equal(5);
   })
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -336,6 +336,10 @@ describe('.count(fn)', function(){
     var arr = Enumerable([1,2,3,4,5]);
     arr.count(function(n){ return n > 3 }).should.equal(2);
   })
+  it('should return total items if no function given', function(){
+    var arr = Enumerable([1,2,3,4,5]);
+    arr.count().should.equal(5);
+  })
 })
 
 describe('.first()', function(){


### PR DESCRIPTION
As far as I can tell, there's no way to access the length of the enumerable's data via the enumerable interface without invoking `__iterator__.length`, or doing `.count(function(){return true})`. This grants access to the length via calling `count()` without a function argument, e.g.

``` js
var arr = Enumerable([1,2,3,4,5]);
arr.count().should.equal(5);
```
