### PR TITLE
Improve performance findLast by returning immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,15 +289,13 @@ proto.find = function(fn){
 
 proto.findLast = function(fn){
   fn = toFunction(fn);
-  var ret;
   var val;
   var vals = this.__iterate__();
   var len = vals.length();
-  for (var i = 0; i < len; ++i) {
+  for (var i = len - 1; i > -1; --i) {
     val = vals.get(i);
-    if (fn(val, i)) ret = val;
+    if (fn(val, i)) return val;
   }
-  return ret;
 };
 
 /**


### PR DESCRIPTION
Changed findLast to start from the end of the array, working its way back, returning as soon as it has found the value.

The previous implementation would always enumerate the entire array.
