### PR TITLE
Some IE8 Compatibility

### DIFF
--- a/component.json
+++ b/component.json
@@ -11,7 +11,8 @@
     "iteration"
   ],
   "dependencies": {
-    "component/to-function": "1.2.0"
+    "component/to-function": "1.2.0",
+    "juliangruber/isarray": "*"
   },
   "development": {},
   "scripts": [

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  */
 
 var toFunction = require('to-function')
+  , isArray = require("isarray")
   , proto = {};
 
 /**
@@ -37,7 +38,7 @@ function mixin(obj){
 
 function Enumerable(obj) {
   if (!(this instanceof Enumerable)) {
-    if (Array.isArray(obj)) return new Enumerable(obj);
+    if (isArray(obj)) return new Enumerable(obj);
     return mixin(obj);
   }
   this.obj = obj;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "enumerable-component",
   "version": "0.3.1",
   "dependencies": {
-    "to-function": "1.2.0"
+    "to-function": "1.2.0",
+    "isarray": "0.0.1"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
While working on adding IE8 compatibility for component/dom, I came across this. (enumerable doesn't have a browser-based test runner atm, but I can add that if we want to ensure it's still compatible)

I've added a new dependency, settling on this particular "isArray" implementation because the same library exists both as a component and an npm module. (otherwise I'd have to do `try...catch` or something around the `require`... yuck)
